### PR TITLE
Method cleanup and fix possible bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ class DBLAPI extends EventEmitter {
        * @param {error} error The error
        */
 
-      this.interval = null
+      this._interval = null
 
       this.client = client;
       const setup = () => {
@@ -57,9 +57,9 @@ class DBLAPI extends EventEmitter {
           .then(() => this.emit('posted'))
           .catch(e => this.emit('error', e));
 
-        if (this.interval) clearInterval(this.interval)
+        if (this._interval) clearInterval(this._interval)
 
-        this.interval = setInterval(() => {
+        this._interval = setInterval(() => {
           this.postStats()
             .then(() => this.emit('posted'))
             .catch(e => this.emit('error', e));

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ class DBLAPI extends EventEmitter {
         }, this.options.statsInterval);
       }
 
-      if (client.readyAt !== null || client.startTime !== null) {
+      if (client.ready || client.ws.status === 0) {
         setup()
       } else {
         client.on('ready', setup.bind(this))

--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ class DBLAPI extends EventEmitter {
 
   /**
    * Gets stats from a bot.
-   * @param {string} id=client.user.id The ID of the bot you want to get the stats from.
+   * @param {string} [id=this.client.user.id] The ID of the bot you want to get the stats from.
    * @returns {Promise<Object>}
    */
   async getStats(id) {
@@ -187,7 +187,7 @@ class DBLAPI extends EventEmitter {
 
   /**
    * Gets information about a bot.
-   * @param {string} id The ID of the bot you want to get the information from.
+   * @param {string} [id=this.client.user.id] The ID of the bot you want to get the information from.
    * @returns {Promise<Object>}
    */
   async getBot(id) {

--- a/src/index.js
+++ b/src/index.js
@@ -53,11 +53,11 @@ class DBLAPI extends EventEmitter {
 
       this.client = client;
       const setup = () => {
+        if (this._interval) return
+
         this.postStats()
           .then(() => this.emit('posted'))
           .catch(e => this.emit('error', e));
-
-        if (this._interval) return
 
         this._interval = setInterval(() => {
           this.postStats()

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ class DBLAPI extends EventEmitter {
           .then(() => this.emit('posted'))
           .catch(e => this.emit('error', e));
 
-        if (this._interval) clearInterval(this._interval)
+        if (this._interval) return
 
         this._interval = setInterval(() => {
           this.postStats()

--- a/src/index.js
+++ b/src/index.js
@@ -143,18 +143,6 @@ class DBLAPI extends EventEmitter {
   }
 
   /**
-   * The clients user ID if client was provided
-   * @type {?string}
-   */
-  get _clientID () {
-    if (this.client) {
-      return this.client.user.id;
-    } else {
-      return null;
-    }
-  }
-
-  /**
    * Post Stats to Discord Bot List.
    * @param {number|number[]} serverCount The server count of your bot.
    * @param {number} [shardId] The ID of this shard.
@@ -190,22 +178,25 @@ class DBLAPI extends EventEmitter {
    * @param {string} id=client.user.id The ID of the bot you want to get the stats from.
    * @returns {Promise<Object>}
    */
-  async getStats(id = this._clientID) {
-    if (!id) throw new Error('getStats requires id as argument');
+  async getStats(id) {
+    if (!id && !this.client) throw new Error('getStats requires id as argument');
+    if (!id) id = this.client.user.id;
     const response = await this._request('get', `bots/${id}/stats`);
     return response.body;
   }
 
   /**
    * Gets information about a bot.
-   * @param {string} id=client.user.id The ID of the bot you want to get the information from.
+   * @param {string} id The ID of the bot you want to get the information from.
    * @returns {Promise<Object>}
    */
-  async getBot(id = this._clientID) {
-    if (!id) throw new Error('getBot requires id as argument');
+  async getBot(id) {
+    if (!id && !this.client) throw new Error('getBot requires id as argument');
+    if (!id) id = this.client.user.id;
     const response = await this._request('get', `bots/${id}`);
     return response.body;
   }
+
 
   /**
    * Gets information about a user.

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,18 @@ class DBLAPI extends EventEmitter {
   }
 
   /**
+   * The clients user ID if client was provided
+   * @type {?string}
+   */
+  get _clientID () {
+    if (this.client) {
+      return this.client.user.id;
+    } else {
+      return null;
+    }
+  }
+
+  /**
    * Post Stats to Discord Bot List.
    * @param {number|number[]} serverCount The server count of your bot.
    * @param {number} [shardId] The ID of this shard.
@@ -175,24 +187,22 @@ class DBLAPI extends EventEmitter {
 
   /**
    * Gets stats from a bot.
-   * @param {string} id The ID of the bot you want to get the stats from.
+   * @param {string} id=client.user.id The ID of the bot you want to get the stats from.
    * @returns {Promise<Object>}
    */
-  async getStats(id) {
-    if (!id && !this.client) throw new Error('getStats requires id as argument');
-    if (!id) id = this.client.user.id;
+  async getStats(id = this._clientID) {
+    if (!id) throw new Error('getStats requires id as argument');
     const response = await this._request('get', `bots/${id}/stats`);
     return response.body;
   }
 
   /**
    * Gets information about a bot.
-   * @param {string} id The ID of the bot you want to get the information from.
+   * @param {string} id=client.user.id The ID of the bot you want to get the information from.
    * @returns {Promise<Object>}
    */
-  async getBot(id) {
-    if (!id && !this.client) throw new Error('getBot requires id as argument');
-    if (!id) id = this.client.user.id;
+  async getBot(id = this._clientID) {
+    if (!id) throw new Error('getBot requires id as argument');
     const response = await this._request('get', `bots/${id}`);
     return response.body;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ class DBLAPI extends EventEmitter {
 
   /**
    * Gets stats from a bot.
-   * @param {string} [id=this.client.user.id] The ID of the bot you want to get the stats from.
+   * @param {string} id The ID of the bot you want to get the stats from.
    * @returns {Promise<Object>}
    */
   async getStats(id) {
@@ -187,7 +187,7 @@ class DBLAPI extends EventEmitter {
 
   /**
    * Gets information about a bot.
-   * @param {string} [id=this.client.user.id] The ID of the bot you want to get the information from.
+   * @param {string} id The ID of the bot you want to get the information from.
    * @returns {Promise<Object>}
    */
   async getBot(id) {

--- a/src/index.js
+++ b/src/index.js
@@ -49,17 +49,28 @@ class DBLAPI extends EventEmitter {
        * @param {error} error The error
        */
 
+      this.interval = null
+
       this.client = client;
-      this.client.on('ready', () => {
+      const setup = () => {
         this.postStats()
           .then(() => this.emit('posted'))
           .catch(e => this.emit('error', e));
-        setInterval(() => {
+
+        if (this.interval) clearInterval(this.interval)
+
+        this.interval = setInterval(() => {
           this.postStats()
             .then(() => this.emit('posted'))
             .catch(e => this.emit('error', e));
         }, this.options.statsInterval);
-      });
+      }
+
+      if (client.readyAt !== null || client.startTime !== null) {
+        setup()
+      } else {
+        client.on('ready', setup.bind(this))
+      }
     } else if (client) {
       console.error(`[dblapi.js autopost] The provided client is not supported. Please add an issue or pull request to the github repo https://github.com/top-gg/dblapi.js`); // eslint-disable-line no-console
     }

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ class DBLAPI extends EventEmitter {
         }, this.options.statsInterval);
       }
 
-      if (client.ready || client.ws.status === 0) {
+      if (client.ready || client.ws && client.ws.status === 0) {
         setup()
       } else {
         client.on('ready', setup.bind(this))

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ class DBLAPI extends EventEmitter {
 
       this.client = client;
       const setup = () => {
-        if (this._interval) return
+        if (this._interval !== null) return
 
         this.postStats()
           .then(() => this.emit('posted'))

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,7 +22,6 @@ declare class DBLAPI extends EventEmitter {
   public token?: string;
 
   private _interval?: number;
-  private _clientID?: string;
   private _request(
     method: string,
     endpoint: string,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -20,7 +20,9 @@ declare class DBLAPI extends EventEmitter {
   public isWeekend(): Promise<boolean>;
 
   public token?: string;
+  public interval?: number;
 
+  private _clientID?: string;
   private _request(
     method: string,
     endpoint: string,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -20,8 +20,8 @@ declare class DBLAPI extends EventEmitter {
   public isWeekend(): Promise<boolean>;
 
   public token?: string;
-  public interval?: number;
 
+  private _interval?: number;
   private _clientID?: string;
   private _request(
     method: string,


### PR DESCRIPTION
~~Changing the use of the default client ID using the built in method defaults~~
and
Making it so that it will still start autopost if dbl is defined after ready, example if someone sets up dbl in the ready event, which I know some people who do.
The same commit also ensures that in case something gets loaded twice (ex 2 ready events from a resume/reconnect) it won't create two separate intervals posting at the same time.

I would've set up the snowflake jsdoc, but I don't trust myself with typings.