### PR TITLE
Fix serverCount argument typing in postStats()

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -86,7 +86,7 @@ declare class DBLAPI extends EventEmitter {
    *
    */
   public postStats(
-    serverCount: number,
+    serverCount: number | number[],
     shardId?: number,
     shardCount?: number
   ): Promise<object>;


### PR DESCRIPTION
- Fixed typing for `serverCount` argument in `postStats()`. It accepts both `number` and `number[]` but it currently has only `number` in typing