### PR TITLE
Updated internal body parser

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,9 @@
 
 # Change Log
 
+## 3.0.6
+  - Fix to webhook, where there were issues when using a body parser that also used `raw-body`
+
 ## 3.0.5
   - Fix to Api.isWeekend example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@top-gg/sdk",
-  "version": "3.0.4",
+  "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@top-gg/sdk",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Official Top.gg Node SDK",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/structs/Webhook.ts
+++ b/src/structs/Webhook.ts
@@ -32,20 +32,24 @@ export class Webhook {
     this.auth = authorization
   }
 
+  private _formatIncoming (body): WebhookPayload {
+    if (body?.query?.length > 0) body.query = qs.parse(body.query.substr(1))
+    return body
+  }
+
   private _parseRequest (req, res): Promise<WebhookPayload|false> {
     return new Promise(resolve => {
       if (this.auth && req.headers.authorization !== this.auth) return res.status(403).json({ error: 'Unauthorized' })
       // parse json
 
+      if (req.body) return resolve(this._formatIncoming(req.body))
       getBody(req, {}, (error, body) => {
         if (error) return res.status(422).json({ error: 'Malformed request' })
 
         try {
-          const parsed = typeof body == 'object' ? body : JSON.parse(body.toString('utf8'))
+          const parsed = JSON.parse(body.toString('utf8'))
 
-          if (parsed?.query?.length > 0) parsed.query = qs.parse(parsed.query.substr(1))
-
-          resolve(parsed)
+          resolve(this._formatIncoming(parsed))
         } catch (err) {
           res.status(400).json({ error: 'Invalid body' })
           resolve(false)

--- a/src/structs/Webhook.ts
+++ b/src/structs/Webhook.ts
@@ -41,7 +41,7 @@ export class Webhook {
         if (error) return res.status(422).json({ error: 'Malformed request' })
 
         try {
-          const parsed = JSON.parse(body.toString('utf8'))
+          const parsed = typeof body == 'object' ? body : JSON.parse(body.toString('utf8'))
 
           if (parsed?.query?.length > 0) parsed.query = qs.parse(parsed.query.substr(1))
 


### PR DESCRIPTION
The old body parse wasn't considering the possibility of express already using its own bodyParser or other types, forcing the user to create another express instance to use path's that required parsed bodies. 
Updated so the body parser internally only triggers when its not type of object.