### PR TITLE
Add express typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,34 +5,95 @@
   "requires": true,
   "dependencies": {
     "@babel/parser": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+      "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
+      "dev": true
+    },
+    "@types/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
+      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
+      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
-      "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==",
+      "version": "14.14.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
       "dev": true
     },
     "@types/node-fetch": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
+      "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
       }
     },
-    "@types/query-string": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-6.3.0.tgz",
-      "integrity": "sha512-yuIv/WRffRzL7cBW+sla4HwBZrEXRNf1MKQ5SklPEadth+BKbDxiVG8A3iISN5B3yC4EeSCzMZP8llHTcUhOzQ==",
+    "@types/qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
+      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
       "dev": true,
       "requires": {
-        "query-string": "*"
+        "@types/mime": "^1",
+        "@types/node": "*"
       }
     },
     "accepts": {
@@ -72,9 +133,9 @@
       }
     },
     "array-back": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-5.0.0.tgz",
+      "integrity": "sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==",
       "dev": true
     },
     "array-flatten": {
@@ -90,9 +151,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "bluebird": {
@@ -176,6 +237,14 @@
         "array-back": "^4.0.1",
         "fs-then-native": "^2.0.0",
         "mkdirp2": "^1.0.4"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+          "dev": true
+        }
       }
     },
     "catharsis": {
@@ -280,9 +349,9 @@
       }
     },
     "common-sequence": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-2.0.0.tgz",
-      "integrity": "sha512-f0QqPLpRTgMQn/pQIynf+SdE73Lw5Q1jn4hjirHLgH/NJ71TiHjXusV16BmOyuK5rRQ1W2f++II+TFZbQOh4hA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-2.0.2.tgz",
+      "integrity": "sha512-jAg09gkdkrDO9EWTdXfv80WWH3yeZl5oT69fGfedBNS9pXUKYInVJ1bJ+/ht2+Moeei48TmSbQDYMc8EOx9G0g==",
       "dev": true
     },
     "concat-map": {
@@ -344,12 +413,6 @@
         "ms": "2.0.0"
       }
     },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
-    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -374,23 +437,23 @@
       "dev": true
     },
     "dmd": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-5.0.2.tgz",
-      "integrity": "sha512-npXsE2+/onRPk/LCrUmx7PcUSqcSVnbrDDMi2nBSawNZ8QXlHE/8xaEZ6pNqPD1lQZv8LGr1xEIpyxP336xyfw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.0.0.tgz",
+      "integrity": "sha512-PwWZlqZnJPETwqZZ70haRa+UDZcD5jeBD3ywW1Kf+jYYv0MHu/S7Ri9jsSoeTMwkcMVW9hXOMA1IZUMEufBhOg==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^5.0.0",
         "cache-point": "^2.0.0",
         "common-sequence": "^2.0.0",
         "file-set": "^4.0.1",
-        "handlebars": "^4.7.6",
-        "marked": "^1.1.0",
+        "handlebars": "^4.7.7",
+        "marked": "^2.0.0",
         "object-get": "^2.1.1",
         "reduce-flatten": "^3.0.0",
         "reduce-unique": "^2.0.1",
         "reduce-without": "^1.0.1",
         "test-value": "^3.0.0",
-        "walk-back": "^4.0.0"
+        "walk-back": "^5.0.0"
       },
       "dependencies": {
         "reduce-flatten": {
@@ -476,12 +539,12 @@
       }
     },
     "file-set": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/file-set/-/file-set-4.0.1.tgz",
-      "integrity": "sha512-tRzX4kGPmxS2HDK2q2L4qcPopTl/gcyahve2/O8l8hHNJgJ7m+r/ZncCJ1MmFWEMp1yHxJGIU9gAcsWu5jPMpg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/file-set/-/file-set-4.0.2.tgz",
+      "integrity": "sha512-fuxEgzk4L8waGXaAkd8cMr73Pm0FxOVkn8hztzUW7BAHhOGH90viQNXbiOsnecCWmfInqU6YmAMwxRMdKETceQ==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^5.0.0",
         "glob": "^7.1.6"
       }
     },
@@ -518,9 +581,9 @@
       }
     },
     "form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
@@ -567,15 +630,15 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -666,49 +729,49 @@
       }
     },
     "jsdoc-api": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-6.0.0.tgz",
-      "integrity": "sha512-zvfB63nAc9e+Rv2kKmJfE6tmo4x8KFho5vKr6VfYTlCCgqtrfPv0McCdqT4betUT9rWtw0zGkNUVkVqeQipY6Q==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-7.0.1.tgz",
+      "integrity": "sha512-SttT7mAvl/L9liIoOoa647ksFlD+fyNP2Vy80MBRi6akOmJQ4ryQjMBOPfg1veKfwVp/8f3My8Bb2JnVGL9wVg==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^5.0.0",
         "cache-point": "^2.0.0",
-        "collect-all": "^1.0.3",
-        "file-set": "^4.0.1",
+        "collect-all": "^1.0.4",
+        "file-set": "^4.0.2",
         "fs-then-native": "^2.0.0",
-        "jsdoc": "^3.6.4",
-        "object-to-spawn-args": "^2.0.0",
+        "jsdoc": "^3.6.6",
+        "object-to-spawn-args": "^2.0.1",
         "temp-path": "^1.0.0",
-        "walk-back": "^4.0.0"
+        "walk-back": "^5.0.0"
       }
     },
     "jsdoc-parse": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-5.0.0.tgz",
-      "integrity": "sha512-Khw8c3glrTeA3/PfUJUBvhrMhWpSClORBUvL4pvq2wFcqvUVmA96wxnMkCno2GfZY4pnd8BStK5WGKGyn4Vckg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.0.0.tgz",
+      "integrity": "sha512-35DhfCHL1bq5r0TvolhyyGhhoem700IfEvviL8I1t99Qxa3aSmWbBEpnvvouA7TyXlwxcQfSg75ryXW8Ppq7FA==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^5.0.0",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
         "reduce-extract": "^1.0.0",
-        "sort-array": "^4.1.1",
+        "sort-array": "^4.1.3",
         "test-value": "^3.0.0"
       }
     },
     "jsdoc-to-markdown": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-6.0.1.tgz",
-      "integrity": "sha512-hUI2PAR5n/KlmQU3mAWO9i3D7jVbhyvUHfQ6oYVBt+wnnsyxpsAuhCODY1ryLOb2U9OPJd4GIK9mL2hqy7fHDg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-7.0.1.tgz",
+      "integrity": "sha512-wN6WAHAPiCyAU7m/+F3FbEEV40CGVWMae49SBPIvfy7kDq/2fBrOw86vdbnLdmjt6u/tHnoxHNrHWYbYFN+4UA==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^5.0.0",
         "command-line-tool": "^0.8.0",
         "config-master": "^3.1.0",
-        "dmd": "^5.0.1",
-        "jsdoc-api": "^6.0.0",
-        "jsdoc-parse": "^5.0.0",
-        "walk-back": "^4.0.0"
+        "dmd": "^6.0.0",
+        "jsdoc-api": "^7.0.0",
+        "jsdoc-parse": "^6.0.0",
+        "walk-back": "^5.0.0"
       }
     },
     "klaw": {
@@ -730,9 +793,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.camelcase": {
@@ -779,9 +842,9 @@
       "dev": true
     },
     "marked": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.7.tgz",
-      "integrity": "sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
       "dev": true
     },
     "mdurl": {
@@ -886,9 +949,9 @@
       "dev": true
     },
     "object-to-spawn-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-2.0.0.tgz",
-      "integrity": "sha512-ZMT4owlXg3JGegecLlAgAA/6BsdKHn63R3ayXcAa3zFkF7oUBHcSb0oxszeutYe0FO2c1lT5pwCuidLkC4Gx3g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-2.0.1.tgz",
+      "integrity": "sha512-6FuKFQ39cOID+BMZ3QaphcC8Y4cw6LXBLyIgPU+OhIYwviJamPAn+4mITapnSBQrejB+NNp+FMskhD8Cq+Ys3w==",
       "dev": true
     },
     "on-finished": {
@@ -942,17 +1005,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true
-    },
-    "query-string": {
-      "version": "6.13.7",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.7.tgz",
-      "integrity": "sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==",
-      "dev": true,
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
     },
     "range-parser": {
       "version": "1.2.1",
@@ -1110,21 +1162,15 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sort-array": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-4.1.3.tgz",
-      "integrity": "sha512-6auiM0DNob/zF+7Ae/SM4BFL5D7DPK/HVcllhVu5V+FgoCPs0A6b6ZwJDuvJpXQgFpxqLZUOD2kdxqO4Z59dkg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-4.1.4.tgz",
+      "integrity": "sha512-GVFN6Y1sHKrWaSYOJTk9093ZnrBMc9sP3nuhANU44S4xg3rE6W5Z5WyamuT8VpMBbssnetx5faKCua0LEmUnSw==",
       "dev": true,
       "requires": {
         "array-back": "^5.0.0",
         "typical": "^6.0.1"
       },
       "dependencies": {
-        "array-back": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-5.0.0.tgz",
-          "integrity": "sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==",
-          "dev": true
-        },
         "typical": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-6.0.1.tgz",
@@ -1137,12 +1183,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
       "dev": true
     },
     "sprintf-js": {
@@ -1180,12 +1220,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
       "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
-      "dev": true
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "dev": true
     },
     "strip-json-comments": {
@@ -1266,6 +1300,12 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true
+    },
     "typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
@@ -1279,9 +1319,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.2.tgz",
-      "integrity": "sha512-rWYleAvfJPjduYCt+ELvzybNah/zIkRteGXIBO8X0lteRZPGladF61hFi8tU7qKTsF7u6DUQCtT9k00VlFOgkg==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
+      "integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
       "dev": true,
       "optional": true
     },
@@ -1309,9 +1349,9 @@
       "dev": true
     },
     "walk-back": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-4.0.0.tgz",
-      "integrity": "sha512-kudCA8PXVQfrqv2mFTG72vDBRi8BKWxGgFLwPpzHcpZnSwZk93WMwUDVcLHWNsnm+Y0AC4Vb6MUNRgaHfyV2DQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.0.0.tgz",
+      "integrity": "sha512-ASerU3aOj9ok+uMNiW0A6/SEwNOxhPmiprbHmPFw1faz7Qmoy9wD3sbmL5HYG+IBxT5c/4cX9O2kSpNv8OAM9A==",
       "dev": true
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
   },
   "homepage": "https://topggjs.rtfd.io",
   "devDependencies": {
-    "@types/node": "^14.14.10",
-    "@types/node-fetch": "^2.5.7",
-    "@types/query-string": "^6.3.0",
+    "@types/express": "^4.17.11",
+    "@types/node": "^14.14.41",
+    "@types/node-fetch": "^2.5.10",
     "express": "^4.17.1",
-    "jsdoc-to-markdown": "^6.0.1"
+    "jsdoc-to-markdown": "^7.0.1",
+    "typescript": "^4.2.4"
   },
   "dependencies": {
     "node-fetch": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@top-gg/sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Official Top.gg Node SDK",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
Installing @top-gg/sdk inside of a TypeScript project results in the following error when building:

```
$ npm run build

> test@1.0.0 build /test
> tsc --build tsconfig.json

node_modules/@top-gg/sdk/dist/structs/Webhook.d.ts:1:49 - error TS2307: Cannot find module 'express' or its corresponding type declarations.

1 import { Request, Response, NextFunction } from 'express';
                                                  ~~~~~~~~~


Found 1 error.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! test@1.0.0 build: `tsc --build tsconfig.json`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the test@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

This PR adds express typings and updates deps.