### PR TITLE
src: replace legacy module

### DIFF
--- a/src/structs/Api.ts
+++ b/src/structs/Api.ts
@@ -35,7 +35,7 @@ export class Api extends EventEmitter {
     }
   }
 
-  private async _request (method: string, path: string, body?: {}): Promise<any> {
+  private async _request (method: string, path: string, body?: Record<string, any>): Promise<any> {
     const headers = new Headers()
     if (this.options.token) headers.set('Authorization', this.options.token)
     if (method !== 'GET') headers.set('Content-Type', 'application/json')

--- a/src/structs/Api.ts
+++ b/src/structs/Api.ts
@@ -42,7 +42,6 @@ export class Api extends EventEmitter {
 
     let url = `https://top.gg/api/${path}`
 
-    // @ts-ignore URLSearchParams typings are records but the value here is a string.
     if (body && method === 'GET') url += `?${new URLSearchParams(body)}`
 
     const response = await fetch(url, {

--- a/src/structs/Api.ts
+++ b/src/structs/Api.ts
@@ -35,7 +35,7 @@ export class Api extends EventEmitter {
     }
   }
 
-  private async _request (method: string, path: string, body?: object): Promise<any> {
+  private async _request (method: string, path: string, body?: {}): Promise<any> {
     const headers = new Headers()
     if (this.options.token) headers.set('Authorization', this.options.token)
     if (method !== 'GET') headers.set('Content-Type', 'application/json')

--- a/src/structs/Api.ts
+++ b/src/structs/Api.ts
@@ -1,6 +1,5 @@
 import fetch, { Headers } from 'node-fetch'
 import ApiError from '../utils/ApiError'
-import qs from 'querystring'
 import { EventEmitter } from 'events'
 
 import { Snowflake, BotStats, BotInfo, UserInfo, BotsResponse, ShortUser, BotsQuery } from '../typings'
@@ -43,8 +42,7 @@ export class Api extends EventEmitter {
 
     let url = `https://top.gg/api/${path}`
 
-    // @ts-ignore querystring typings are messed
-    if (body && method === 'GET') url += `?${qs.stringify(body)}`
+    if (body && method === 'GET') url += `?${new URLSearchParams(body)}`
 
     const response = await fetch(url, {
       method,

--- a/src/structs/Api.ts
+++ b/src/structs/Api.ts
@@ -42,6 +42,7 @@ export class Api extends EventEmitter {
 
     let url = `https://top.gg/api/${path}`
 
+    // @ts-ignore URLSearchParams typings are records but the value here is a string.
     if (body && method === 'GET') url += `?${new URLSearchParams(body)}`
 
     const response = await fetch(url, {

--- a/src/structs/Webhook.ts
+++ b/src/structs/Webhook.ts
@@ -1,5 +1,4 @@
 import getBody from 'raw-body'
-import qs from 'querystring'
 
 import { Request, Response, NextFunction } from 'express'
 
@@ -47,7 +46,7 @@ export class Webhook {
   }
 
   private _formatIncoming (body): WebhookPayload {
-    if (body?.query?.length > 0) body.query = qs.parse(body.query.substr(1))
+    if (body?.query?.length > 0) body.query = Object.fromEntries(new URLSearchParams(body.query.substr(1)))
     return body
   }
 

--- a/src/structs/Webhook.ts
+++ b/src/structs/Webhook.ts
@@ -46,7 +46,7 @@ export class Webhook {
   }
 
   private _formatIncoming (body): WebhookPayload {
-    if (body?.query?.length > 0) body.query = Object.fromEntries(new URLSearchParams(body.query.substr(1)))
+    if (body?.query?.length > 0) body.query = Object.fromEntries(new URLSearchParams(body.query))
     return body
   }
 


### PR DESCRIPTION
The `querystring` module is legacy now, it is recommended to use the built-in `URLSearchParams` constructor.