### PR TITLE
fix: deprecate missing property in `ShortUser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@top-gg/sdk",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Official Top.gg Node SDK",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/structs/Api.ts
+++ b/src/structs/Api.ts
@@ -252,13 +252,11 @@ export class Api extends EventEmitter {
    * [
    *   {
    *     username: 'Xignotic',
-   *     discriminator: '0001',
    *     id: '205680187394752512',
    *     avatar: '3b9335670c7213b3a2d4e990081900c7'
    *   },
    *   {
    *     username: 'iara',
-   *     discriminator: '0001',
    *     id: '395526710101278721',
    *     avatar: '3d1477390b8d7c3cec717ac5c778f5f4'
    *   }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -150,6 +150,12 @@ export interface ShortUser {
   id: Snowflake;
   /** User's username */
   username: string;
+  /**
+   * User's discriminator
+   *
+   * @deprecated
+   */
+  discriminator: string;
   /** User's avatar hash */
   avatar: string;
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -150,8 +150,6 @@ export interface ShortUser {
   id: Snowflake;
   /** User's username */
   username: string;
-  /** User's discriminator */
-  discriminator: string;
   /** User's avatar hash */
   avatar: string;
 }


### PR DESCRIPTION
The `discriminator` property doesn't exist in the objects returned in `/bots/votes`. (see https://docs.top.gg/api/bot/#example-response-1)