### PR TITLE
meta: update GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [16, 18, 20]
     steps:
       - uses: actions/checkout@v3
       - name: Cache node_modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: 18
+          check-latest: true
+          registry-url: https://registry.npmjs.org/
       - name: Install Dependencies
         run: npm install
       - name: Run Jest tests


### PR DESCRIPTION
- Remove Node.js v14 from the test matrix as it has reached its EoL (End-of-Life) stage, and add Node.js v20 to the test matrix.
- Update actions to their latest versions.