### PR TITLE
deps: replace `raw-body` with native approach

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@top-gg/sdk",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Official Top.gg Node SDK",
   "main": "./dist/index.js",
   "scripts": {
@@ -44,8 +44,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "raw-body": "^2.5.2",
-    "undici": "^5.23.0"
+    "undici": "^6.13.0"
   },
   "types": "./dist/index.d.ts"
 }


### PR DESCRIPTION
`raw-body` was used in a way that it only converted the request to a Buffer. This PR replaces usage of `raw-body` with a less complex, native approach, removing not just the 11 dependencies that came with `raw-body`, but also `undici`'s only subdependency (that was gone after updating `undici`). As such this PR lowers the amount of transitive dependencies in this package from [13](https://npmgraph.js.org/?q=@top-gg/sdk@3.1.6) down to [one](https://npmgraph.js.org/?q=https%3A%2F%2Fraw.githubusercontent.com%2FTop-gg-Community%2Fnode-sdk%2F573af086f3759e7677234db3cdeac9c7a6f5d662%2Fpackage.json) (1). 

I've tested that this approach and the way `raw-body` was used both give the same output, making this a free ~40% decrease in total bundle size
<details><summary>Code I ran to test</summary>

https://runkit.com/embed/4hcq12gepy26

 ![image](https://github.com/Top-gg-Community/node-sdk/assets/53496941/2f10f863-5433-4ff3-acaf-ad3c660650d5)

</details> 
