### PR TITLE
ci: remove dependence on @top-gg/eslint-config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,0 @@
-module.exports = {
-  ignorePatterns: ["node_modules/*", "docs/*", "dist/*"],
-  extends: "@top-gg/eslint-config",
-  parserOptions: {
-    project: "./tsconfig.json",
-  }
-};

--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,7 @@ logs/
 *.log
 
 !dist/
-.eslintrc.json
+eslint.config.js
 .gitattributes
 .gitignore
 .github/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,81 @@
+const js = require('@eslint/js');
+const ts = require("@typescript-eslint/eslint-plugin");
+
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+const jestPlugin = require('eslint-plugin-jest');
+
+module.exports = [
+  {
+    ignores: ["node_modules/*", "docs/*", "dist/*"]
+  },
+  {
+    ...js.configs.recommended,
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: require('@typescript-eslint/parser'),
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+      globals: {
+        es6: true,
+        browser: true,
+        node: true,
+        jest: true
+      }
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+      jest: jestPlugin
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      semi: "error",
+      "no-unreachable-loop": "warn",
+      "no-unsafe-optional-chaining": "warn",
+      eqeqeq: "error",
+      "no-alert": "error",
+      "prefer-spread": "error",
+      "no-duplicate-imports": "warn",
+      "no-eval": "error",
+      "no-implied-eval": "error",
+      "no-extend-native": "warn",
+      "no-new-wrappers": "error",
+      "no-proto": "error",
+      "no-script-url": "error",
+      "no-self-compare": "warn",
+      "no-useless-catch": "warn",
+      "no-throw-literal": "error",
+      "no-var": "warn",
+      "no-labels": "error",
+      "no-undefined": "off",
+      "no-new-object": "error",
+      "no-multi-assign": "warn",
+      "prefer-const": "warn",
+      "prefer-numeric-literals": "warn",
+      "prefer-object-spread": "error",
+      "prefer-rest-params": "error",
+      "prefer-exponentiation-operator": "error",
+      "no-lonely-if": "error",
+      radix: "warn",
+      camelcase: "warn",
+      "new-cap": "error",
+      quotes: ["warn", "double", { allowTemplateLiterals: true }],
+      "no-void": "error",
+      "spaced-comment": ["warn", "always"],
+      "eol-last": "warn",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/prefer-optional-chain": "error",
+      "@typescript-eslint/prefer-for-of": "error",
+      "@typescript-eslint/no-namespace": [
+        "error",
+        { allowDefinitionFiles: true }
+      ]
+    }
+  },
+  {
+    files: ["*.browser.js"],
+    env: {
+      browser: true
+    }
+  }
+];

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://topgg.js.org",
   "devDependencies": {
-    "@top-gg/eslint-config": "^0.0.4",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.4",
     "@types/node": "^20.5.9",


### PR DESCRIPTION
The following pull request is split from #92. It updates the SDK's eslint rules by replacing the now-deprecated `.eslintrc.js` with `eslint.config.js` and removing dependence on the soon-to-be-archived [`@top-gg/eslint-config`](https://github.com/top-gg/eslint-config).

[Conversational reference from July 2025](https://discord.com/channels/264445053596991498/844289669118427226/1393777572743221309).