### PR TITLE
Add missing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,16 @@ The community-maintained Node.js SDK for Top.gg.
 - [Setting up](#setting-up)
 - [Usage](#usage)
   - [Getting your project's information](#getting-your-projects-information)
+  - [Updating your project's information](#updating-your-projects-information)
   - [Getting your project's vote information of a user](#getting-your-projects-vote-information-of-a-user)
   - [Getting a cursor-based paginated list of votes for your project](#getting-a-cursor-based-paginated-list-of-votes-for-your-project)
+  - [Posting an announcement for your project](#posting-an-announcement-for-your-project)
+  - [Posting your project's metric stats](#posting-your-projects-metric-stats)
   - [Posting your bot's application commands list](#posting-your-bots-application-commands-list)
   - [Generating widget URLs](#generating-widget-urls)
   - [Webhooks](#webhooks)
 
 ## Installation
-
 
 ### NPM
 
@@ -71,6 +73,19 @@ console.log(project);
 // }
 ```
 
+### Updating your project's information
+
+```js
+await client.editSelf({
+  headline: {
+    "en": "A great bot with tons of features!"
+  },
+  content: {
+    "en": "# Welcome\nThis is the full page description for your project..."
+  }
+});
+```
+
 ### Getting your project's vote information of a user
 
 #### Discord ID
@@ -95,6 +110,46 @@ console.log(firstPage.votes);
 
 const secondPage = await firstPage.next();
 console.log(secondPage.votes);
+```
+
+### Posting an announcement for your project 
+
+```js
+const announcement = await client.postAnnouncement(
+  "Version 2.0 Released!",
+  "We just released version 2.0 with a bunch of new features and improvements."
+);
+
+console.log(announcement)
+// =>
+// {
+//   title: "Version 2.0 Released!",
+//   content: "We just released version 2.0 with a bunch of new features and improvements.",
+//   createdAt: "2026-03-14T15:09:26Z"
+// }
+```
+
+### Posting your project's metric stats
+
+#### Single
+
+```js
+await client.postMetrics({ serverCount: 420, shardCount: 53 });
+```
+
+#### Batch
+
+```js
+await client.postMetrics([
+  {
+    timestamp: "2026-04-17T10:00:00Z",
+    serverCount: 420,
+    shardCount: 53
+  },
+  {
+    serverCount: 435
+  }
+]);
 ```
 
 ### Posting your bot's application commands list

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ console.log(project);
 ```js
 await client.editSelf({
   headline: {
-    "en": "A great bot with tons of features!"
+    en: "A great bot with tons of features!"
   },
   content: {
-    "en": "# Welcome\nThis is the full page description for your project..."
+    en: "# Welcome\nThis is the full page description for your project..."
   }
 });
 ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,7 +55,7 @@ export default [
       "prefer-exponentiation-operator": "error",
       "no-lonely-if": "error",
       radix: "warn",
-      camelcase: "warn",
+      camelcase: ["warn", { properties: "never" }],
       "new-cap": "error",
       quotes: ["warn", "double", { allowTemplateLiterals: true }],
       "no-void": "error",

--- a/src/structs/Api.ts
+++ b/src/structs/Api.ts
@@ -13,7 +13,7 @@ import type {
   Announcement,
   Method,
   MetricsPayload,
-  ProjectPayload
+  ProjectPayload,
 } from "../typings.js";
 
 /** The API version to use */
@@ -49,14 +49,14 @@ export class Api extends EventEmitter {
 
     this.options = {
       token,
-      ...options
+      ...options,
     };
   }
 
   private async _request(
     method: Method,
     path: string,
-    body?: Record<string, any>
+    body?: Record<string, any>,
   ): Promise<any> {
     const headers = new Headers();
 
@@ -67,7 +67,7 @@ export class Api extends EventEmitter {
     const response = await fetch(BASE_URL + path, {
       method,
       headers,
-      body: body && method !== "GET" ? JSON.stringify(body) : undefined
+      body: body && method !== "GET" ? JSON.stringify(body) : undefined,
     });
 
     let responseBody: string | object | undefined;
@@ -132,12 +132,12 @@ export class Api extends EventEmitter {
       tags: project.tags,
       votes: {
         current: project.votes,
-        total: project.votes_total
+        total: project.votes_total,
       },
       review: {
         score: project.review_score,
-        count: project.review_count
-      }
+        count: project.review_count,
+      },
     };
   }
 
@@ -161,8 +161,8 @@ export class Api extends EventEmitter {
    */
   public async editSelf(options: ProjectPayload): Promise<void> {
     await this._request("PATCH", "/projects/@me", {
-      "headline": options.headline,
-      "page_content": options.content
+      headline: options.headline,
+      page_content: options.content,
     });
   }
 
@@ -203,14 +203,14 @@ export class Api extends EventEmitter {
 
   /**
    * Creates a new announcement for your project. Announcements appear on your project's page and can be used to notify users about updates, new features, or other news.
-   * 
+   *
    * @example
    * ```js
    * const announcement = await client.postAnnouncement(
    *    "Version 2.0 Released!",
    *    "We just released version 2.0 with a bunch of new features and improvements."
    * );
-   * 
+   *
    * console.log(announcement)
    * // =>
    * // {
@@ -219,51 +219,58 @@ export class Api extends EventEmitter {
    * //   createdAt: "2026-03-14T15:09:26Z"
    * // }
    * ```
-   * 
+   *
    * @param {string} title The announcement title. Must be between 3 and 100 characters.
    * @param {string} content The announcement body text. Must be between 10 and 2,000 characters.
    * @returns {Promise<Announcement>} The created announcement.
    */
-  public async postAnnouncement(title: string, content: string): Promise<Announcement> {
-    const announcement = await this._request("POST", "/projects/@me/announcements", { title, content });
+  public async postAnnouncement(
+    title: string,
+    content: string,
+  ): Promise<Announcement> {
+    const announcement = await this._request(
+      "POST",
+      "/projects/@me/announcements",
+      { title, content },
+    );
 
     return {
       title: announcement.title,
       content: announcement.content,
-      createdAt: announcement.created_at
+      createdAt: announcement.created_at,
     };
   }
 
   private _parseMetrics(payload: MetricsPayload) {
     if ("serverCount" in payload || "shardCount" in payload) {
       return {
-        "server_count": payload.serverCount,
-        "shard_count": payload.shardCount
+        server_count: payload.serverCount,
+        shard_count: payload.shardCount,
       };
-    };
+    }
 
     if ("memberCount" in payload || "onlineCount" in payload) {
       return {
-        "member_count": payload.memberCount,
-        "online_count": payload.onlineCount
+        member_count: payload.memberCount,
+        online_count: payload.onlineCount,
       };
-    };
+    }
 
     if ("playerCount" in payload) {
       return {
-        "player_count": payload.playerCount
+        player_count: payload.playerCount,
       };
-    };
+    }
   }
 
   /**
    * Submits a single or batch of metrics payloads for your project. Use this to push fresh numbers after an event such as joining or leaving a guild or a player connecting.
-   * 
+   *
    * @example
    * ```js
    * // Single
    * await client.postMetrics({ serverCount: 420, shardCount: 53 });
-   * 
+   *
    * // Batch
    * await client.postMetrics([
    *  {
@@ -276,20 +283,27 @@ export class Api extends EventEmitter {
    *  }
    * ]);
    * ```
-   * 
+   *
    * @param payload The metrics payload. Can be a single object or an array of objects with up to 100 entries.
    * @returns {Promise<void>}
    */
   public async postMetrics(
-    payload: MetricsPayload | (MetricsPayload & { timestamp?: string })[]
+    payload: MetricsPayload | (MetricsPayload & { timestamp?: string })[],
   ): Promise<void> {
     if (!Array.isArray(payload)) {
-      await this._request("PATCH", "/projects/@me/metrics", this._parseMetrics(payload));
+      await this._request(
+        "PATCH",
+        "/projects/@me/metrics",
+        this._parseMetrics(payload),
+      );
       return;
-    };
+    }
 
     await this._request("POST", "/projects/@me/metrics/batch", {
-      data: payload.map(({ timestamp, ...metrics }) => ({ timestamp, metrics: this._parseMetrics(metrics) }))
+      data: payload.map(({ timestamp, ...metrics }) => ({
+        timestamp,
+        metrics: this._parseMetrics(metrics),
+      })),
     });
   }
 
@@ -311,20 +325,20 @@ export class Api extends EventEmitter {
    */
   public async getVote(
     id: Snowflake,
-    source: UserSource = "discord"
+    source: UserSource = "discord",
   ): Promise<PartialVote | null> {
     if (!id) throw new Error("Missing ID");
 
     try {
       const response = await this._request(
         "GET",
-        `/projects/@me/votes/${id}?source=${source}`
+        `/projects/@me/votes/${id}?source=${source}`,
       );
 
       return {
         votedAt: new Date(response.created_at),
         expiresAt: new Date(response.expires_at),
-        weight: response.weight
+        weight: response.weight,
       };
     } catch (err) {
       const topggError = err as TopGGAPIError;
@@ -343,7 +357,7 @@ export class Api extends EventEmitter {
   }): Promise<PaginatedVotes> {
     const response = await this._request(
       "GET",
-      `/projects/@me/votes?${options.since ? `startDate=${encodeURIComponent(options.since.toISOString())}` : `cursor=${options.cursor}`}`
+      `/projects/@me/votes?${options.since ? `startDate=${encodeURIComponent(options.since.toISOString())}` : `cursor=${options.cursor}`}`,
     );
     /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     const self = this;
@@ -354,12 +368,12 @@ export class Api extends EventEmitter {
         platformId: vote.platform_id,
         votedAt: new Date(vote.created_at),
         expiresAt: new Date(vote.expires_at),
-        weight: vote.weight
+        weight: vote.weight,
       })),
       next: () =>
         self._getVotesInner({
-          cursor: response.cursor
-        })
+          cursor: response.cursor,
+        }),
     };
   }
 

--- a/src/structs/Api.ts
+++ b/src/structs/Api.ts
@@ -9,7 +9,11 @@ import type {
   UserSource,
   Project,
   PartialVote,
-  PaginatedVotes
+  PaginatedVotes,
+  Announcement,
+  Method,
+  MetricsPayload,
+  ProjectPayload
 } from "../typings.js";
 
 /** The API version to use */
@@ -50,7 +54,7 @@ export class Api extends EventEmitter {
   }
 
   private async _request(
-    method: string,
+    method: Method,
     path: string,
     body?: Record<string, any>
   ): Promise<any> {
@@ -138,6 +142,31 @@ export class Api extends EventEmitter {
   }
 
   /**
+   * Updates the headline and/or page content for your project. Both fields are locale-keyed, so you can set content for multiple languages in a single request.
+   *
+   * @example
+   * ```js
+   * await client.editSelf({
+   *  headline: {
+   *    "en": "A great bot with tons of features!"
+   *  },
+   *  content: {
+   *    "en": "# Welcome\nThis is the full page description for your project..."
+   *  }
+   * });
+   * ```
+   *
+   * @param {ProjectPayload} options The project payload options.
+   * @returns {Promise<void>}
+   */
+  public async editSelf(options: ProjectPayload): Promise<void> {
+    await this._request("PATCH", "/projects/@me", {
+      "headline": options.headline,
+      "page_content": options.content
+    });
+  }
+
+  /**
    * Updates the application commands list in your Discord bot's Top.gg page.
    *
    * @example
@@ -170,6 +199,98 @@ export class Api extends EventEmitter {
    */
   public async postCommands(commands: APIApplicationCommand[]): Promise<void> {
     await this._request("POST", "/projects/@me/commands", commands);
+  }
+
+  /**
+   * Creates a new announcement for your project. Announcements appear on your project's page and can be used to notify users about updates, new features, or other news.
+   * 
+   * @example
+   * ```js
+   * const announcement = await client.postAnnouncement(
+   *    "Version 2.0 Released!",
+   *    "We just released version 2.0 with a bunch of new features and improvements."
+   * );
+   * 
+   * console.log(announcement)
+   * // =>
+   * // {
+   * //   title: "Version 2.0 Released!",
+   * //   content: "We just released version 2.0 with a bunch of new features and improvements.",
+   * //   createdAt: "2026-03-14T15:09:26Z"
+   * // }
+   * ```
+   * 
+   * @param {string} title The announcement title. Must be between 3 and 100 characters.
+   * @param {string} content The announcement body text. Must be between 10 and 2,000 characters.
+   * @returns {Promise<Announcement>} The created announcement.
+   */
+  public async postAnnouncement(title: string, content: string): Promise<Announcement> {
+    const announcement = await this._request("POST", "/projects/@me/announcements", { title, content });
+
+    return {
+      title: announcement.title,
+      content: announcement.content,
+      createdAt: announcement.created_at
+    };
+  }
+
+  private _parseMetrics(payload: MetricsPayload) {
+    if ("serverCount" in payload || "shardCount" in payload) {
+      return {
+        "server_count": payload.serverCount,
+        "shard_count": payload.shardCount
+      };
+    };
+
+    if ("memberCount" in payload || "onlineCount" in payload) {
+      return {
+        "member_count": payload.memberCount,
+        "online_count": payload.onlineCount
+      };
+    };
+
+    if ("playerCount" in payload) {
+      return {
+        "player_count": payload.playerCount
+      };
+    };
+  }
+
+  /**
+   * Submits a single or batch of metrics payloads for your project. Use this to push fresh numbers after an event such as joining or leaving a guild or a player connecting.
+   * 
+   * @example
+   * ```js
+   * // Single
+   * await client.postMetrics({ serverCount: 420, shardCount: 53 });
+   * 
+   * // Batch
+   * await client.postMetrics([
+   *  {
+   *    timestamp: "2026-04-17T10:00:00Z",
+   *    serverCount: 420,
+   *    shardCount: 53
+   *  },
+   *  {
+   *    serverCount: 435
+   *  }
+   * ]);
+   * ```
+   * 
+   * @param payload The metrics payload.
+   * @returns {Promise<void>}
+   */
+  public async postMetrics(
+    payload: MetricsPayload | (MetricsPayload & { timestamp?: string })[]
+  ): Promise<void> {
+    if (!Array.isArray(payload)) {
+      await this._request("PATCH", "/projects/@me/metrics", this._parseMetrics(payload));
+      return;
+    };
+
+    await this._request("POST", "/projects/@me/metrics/batch", {
+      data: payload.map(({ timestamp, ...metrics }) => ({ timestamp, metrics: this._parseMetrics(metrics) }))
+    });
   }
 
   /**

--- a/src/structs/Api.ts
+++ b/src/structs/Api.ts
@@ -277,7 +277,7 @@ export class Api extends EventEmitter {
    * ]);
    * ```
    * 
-   * @param payload The metrics payload.
+   * @param payload The metrics payload. Can be a single object or an array of objects with up to 100 entries.
    * @returns {Promise<void>}
    */
   public async postMetrics(

--- a/src/structs/Webhook.ts
+++ b/src/structs/Webhook.ts
@@ -8,7 +8,7 @@ import type {
   VoteCreatePayload,
   WebhookPayload,
   WebhookPayloadType,
-  WebhookTestPayload
+  WebhookTestPayload,
 } from "../typings.js";
 import { API_VERSION } from "./Api.js";
 import getBody from "raw-body";
@@ -68,7 +68,7 @@ export class Webhook {
     this.options = {
       error: options.error ?? console.error,
       timeout: options.timeout ?? 5000,
-      timestampWindow: options.timestampWindow ?? 30000
+      timestampWindow: options.timestampWindow ?? 30000,
     };
   }
 
@@ -77,7 +77,7 @@ export class Webhook {
       id: project.id,
       type: project.type,
       platform: project.platform,
-      platformId: project.platform_id
+      platformId: project.platform_id,
     };
   }
 
@@ -86,7 +86,7 @@ export class Webhook {
       id: user.id,
       name: user.name,
       avatar: user.avatar_url,
-      platformId: user.platform_id
+      platformId: user.platform_id,
     };
   }
 
@@ -95,7 +95,7 @@ export class Webhook {
       type: WebhookPayloadType;
       data: any;
     },
-    trace: string | string[] | undefined
+    trace: string | string[] | undefined,
   ): WebhookPayload {
     let data;
 
@@ -105,7 +105,7 @@ export class Webhook {
           connectionId: body.data.connection_id,
           secret: body.data.webhook_secret,
           project: this._formatPartialProject(body.data.project),
-          user: this._formatUser(body.data.user)
+          user: this._formatUser(body.data.user),
         } as IntegrationCreatePayload;
 
         this.secret = data.secret;
@@ -115,7 +115,7 @@ export class Webhook {
 
       case "integration.delete": {
         data = {
-          connectionId: body.data.connection_id
+          connectionId: body.data.connection_id,
         } as IntegrationDeletePayload;
 
         break;
@@ -128,7 +128,7 @@ export class Webhook {
           votedAt: new Date(body.data.created_at),
           expiresAt: new Date(body.data.expires_at),
           project: this._formatPartialProject(body.data.project),
-          user: this._formatUser(body.data.user)
+          user: this._formatUser(body.data.user),
         } as VoteCreatePayload;
 
         break;
@@ -137,7 +137,7 @@ export class Webhook {
       case "webhook.test": {
         data = {
           project: this._formatPartialProject(body.data.project),
-          user: this._formatUser(body.data.user)
+          user: this._formatUser(body.data.user),
         } as WebhookTestPayload;
 
         break;
@@ -151,13 +151,13 @@ export class Webhook {
     return {
       type: body.type,
       data,
-      trace
+      trace,
     };
   }
 
   private _parseRequest(
     req: Request,
-    res: Response
+    res: Response,
   ): Promise<WebhookPayload | false> {
     const currentTimestamp = Date.now();
 
@@ -165,7 +165,7 @@ export class Webhook {
       getBody(
         req,
         {
-          limit: 2 * 1024 * 1024
+          limit: 2 * 1024 * 1024,
         },
         (error, body) => {
           /* node:coverage ignore next 4 */
@@ -187,7 +187,7 @@ export class Webhook {
           }
 
           const parsedSignature = Object.fromEntries(
-            signatureHeader.split(",").map((part) => part.split("="))
+            signatureHeader.split(",").map((part) => part.split("=")),
           );
           const signature = parsedSignature[API_VERSION];
 
@@ -199,7 +199,7 @@ export class Webhook {
           if (
             this.options.timestampWindow &&
             Math.abs(
-              currentTimestamp - parseInt(parsedSignature.t, 10) * 1000
+              currentTimestamp - parseInt(parsedSignature.t, 10) * 1000,
             ) > this.options.timestampWindow
           ) {
             res
@@ -211,7 +211,7 @@ export class Webhook {
           const hmac = crypto.createHmac("sha256", this.secret);
           const digest = Buffer.from(
             hmac.update(`${parsedSignature.t}.${body}`).digest("hex"),
-            "hex"
+            "hex",
           );
 
           if (!crypto.timingSafeEqual(Buffer.from(signature, "hex"), digest)) {
@@ -225,19 +225,19 @@ export class Webhook {
             const parsed = JSON.parse(bodyString);
 
             return resolve(
-              this._formatIncoming(parsed, req.headers["x-topgg-trace"])
+              this._formatIncoming(parsed, req.headers["x-topgg-trace"]),
             );
           } catch (err: any) {
             /* node:coverage ignore next 3 */
             console.warn(
-              `[WARNING] Unable to parse Top.gg webhook payload. Please report this bug to the SDK maintainers.\nCause: ${err.stack || err.message || err}\n--- BEGIN BODY DUMP ---\n${bodyString}\n--- END BODY DUMP ---`
+              `[WARNING] Unable to parse Top.gg webhook payload. Please report this bug to the SDK maintainers.\nCause: ${err.stack || err.message || err}\n--- BEGIN BODY DUMP ---\n${bodyString}\n--- END BODY DUMP ---`,
             );
 
             res.sendStatus(204);
 
             return resolve(false);
           }
-        }
+        },
       );
 
       setTimeout(() => {
@@ -281,13 +281,13 @@ export class Webhook {
       payload: WebhookPayload,
       req: Request,
       res: Response,
-      next: NextFunction
-    ) => void | Promise<void>
+      next: NextFunction,
+    ) => void | Promise<void>,
   ) {
     return async (
       req: Request,
       res: Response,
-      next: NextFunction
+      next: NextFunction,
     ): Promise<void> => {
       const response = await this._parseRequest(req, res);
       if (!response) return;

--- a/src/structs/Widget.ts
+++ b/src/structs/Widget.ts
@@ -17,7 +17,7 @@ export class Widget {
   public static large(
     platform: Platform,
     projectType: ProjectType,
-    id: Snowflake
+    id: Snowflake,
   ): string {
     return `${BASE_URL}/large/${platform}/${projectType}/${id}`;
   }
@@ -33,7 +33,7 @@ export class Widget {
   public static votes(
     platform: Platform,
     projectType: ProjectType,
-    id: Snowflake
+    id: Snowflake,
   ): string {
     return `${BASE_URL}/small/votes/${platform}/${projectType}/${id}`;
   }
@@ -49,7 +49,7 @@ export class Widget {
   public static owner(
     platform: Platform,
     projectType: ProjectType,
-    id: Snowflake
+    id: Snowflake,
   ): string {
     return `${BASE_URL}/small/owner/${platform}/${projectType}/${id}`;
   }
@@ -65,7 +65,7 @@ export class Widget {
   public static social(
     platform: Platform,
     projectType: ProjectType,
-    id: Snowflake
+    id: Snowflake,
   ): string {
     return `${BASE_URL}/small/social/${platform}/${projectType}/${id}`;
   }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,6 +1,8 @@
 /** Discord ID */
 export type Snowflake = string;
 
+export type Method = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+
 export interface APIOptions {
   /** Top.gg API token */
   token?: string;
@@ -16,6 +18,25 @@ export type Platform = "discord";
 
 /** A project's type */
 export type ProjectType = "bot" | "server";
+
+/** A locale for a project's payload */
+export type Locale =
+  | "en"
+  | "de"
+  | "fr"
+  | "pt"
+  | "tr"
+  | "hi"
+  | "ja"
+  | "ar"
+  | "nl"
+  | "ko"
+  | "it"
+  | "es"
+  | "ru"
+  | "uk"
+  | "vi"
+  | "zh"
 
 /** A webhook payload's type */
 export type WebhookPayloadType =
@@ -54,6 +75,13 @@ export interface Project {
   };
 }
 
+export interface ProjectPayload {
+  /** The project's short description */
+  headline?: Record<Locale, string>;
+  /** The project's page content */
+  content?: Record<Locale, string>;
+}
+
 /** A brief information on a project listed on Top.gg */
 export interface PartialProject {
   /** The project's ID */
@@ -90,6 +118,16 @@ export interface PaginatedVotes {
   votes: Vote[];
   /** Tries to advance to the next page */
   next(): Promise<PaginatedVotes>;
+}
+
+/** An announcement of a project */
+export interface Announcement {
+  /** The announcement's title */
+  title: string;
+  /** The announcement's content */
+  content: string;
+  /** The announcement's creation timestamp */
+  createdAt: string;
 }
 
 /** A Top.gg user */
@@ -152,13 +190,34 @@ export interface WebhookPayload {
   type: WebhookPayloadType;
   /** The payload's data */
   data:
-    | IntegrationCreatePayload
-    | IntegrationDeletePayload
-    | VoteCreatePayload
-    | WebhookTestPayload;
+  | IntegrationCreatePayload
+  | IntegrationDeletePayload
+  | VoteCreatePayload
+  | WebhookTestPayload;
   /** The payload's x-topgg-trace header for debugging and correlating requests with Top.gg support */
   trace: string | string[] | undefined;
 }
+
+export interface DiscordBotPayload {
+  /** The total number of servers the bot is currently in */
+  serverCount?: number;
+  /** The number of shards the bot is currently running */
+  shardCount?: number;
+}
+
+export interface DiscordServerPayload {
+  /** The total number of members in the server */
+  memberCount?: number;
+  /** The number of members currently online */
+  onlineCount?: number;
+}
+
+export interface RobloxGamePayload {
+  /** The current number of players in the game */
+  playerCount: number;
+}
+
+export type MetricsPayload = DiscordBotPayload | DiscordServerPayload | RobloxGamePayload
 
 declare module "express" {
   export interface Request {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -75,6 +75,7 @@ export interface Project {
   };
 }
 
+/** A project payload */
 export interface ProjectPayload {
   /** The project's short description */
   headline?: Partial<Record<Locale, string>>;
@@ -198,6 +199,7 @@ export interface WebhookPayload {
   trace: string | string[] | undefined;
 }
 
+/** A Discord bot payload */
 export interface DiscordBotPayload {
   /** The total number of servers the bot is currently in */
   serverCount?: number;
@@ -205,6 +207,7 @@ export interface DiscordBotPayload {
   shardCount?: number;
 }
 
+/** A Discord server payload */
 export interface DiscordServerPayload {
   /** The total number of members in the server */
   memberCount?: number;
@@ -212,11 +215,13 @@ export interface DiscordServerPayload {
   onlineCount?: number;
 }
 
+/** A Roblox game payload */
 export interface RobloxGamePayload {
   /** The current number of players in the game */
   playerCount: number;
 }
 
+/** A metrics payload */
 export type MetricsPayload = DiscordBotPayload | DiscordServerPayload | RobloxGamePayload
 
 declare module "express" {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -36,7 +36,7 @@ export type Locale =
   | "ru"
   | "uk"
   | "vi"
-  | "zh"
+  | "zh";
 
 /** A webhook payload's type */
 export type WebhookPayloadType =
@@ -191,10 +191,10 @@ export interface WebhookPayload {
   type: WebhookPayloadType;
   /** The payload's data */
   data:
-  | IntegrationCreatePayload
-  | IntegrationDeletePayload
-  | VoteCreatePayload
-  | WebhookTestPayload;
+    | IntegrationCreatePayload
+    | IntegrationDeletePayload
+    | VoteCreatePayload
+    | WebhookTestPayload;
   /** The payload's x-topgg-trace header for debugging and correlating requests with Top.gg support */
   trace: string | string[] | undefined;
 }
@@ -222,7 +222,10 @@ export interface RobloxGamePayload {
 }
 
 /** A metrics payload */
-export type MetricsPayload = DiscordBotPayload | DiscordServerPayload | RobloxGamePayload
+export type MetricsPayload =
+  | DiscordBotPayload
+  | DiscordServerPayload
+  | RobloxGamePayload;
 
 declare module "express" {
   export interface Request {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -77,9 +77,9 @@ export interface Project {
 
 export interface ProjectPayload {
   /** The project's short description */
-  headline?: Record<Locale, string>;
+  headline?: Partial<Record<Locale, string>>;
   /** The project's page content */
-  content?: Record<Locale, string>;
+  content?: Partial<Record<Locale, string>>;
 }
 
 /** A brief information on a project listed on Top.gg */

--- a/src/utils/ApiError.ts
+++ b/src/utils/ApiError.ts
@@ -4,7 +4,7 @@ const tips = {
   403: "You don't have access to this endpoint",
   404: "Route not found",
   429: "The client is blocked by the API. Please try again in a few moments",
-  500: "Received an unexpected error from Top.gg's end"
+  500: "Received an unexpected error from Top.gg's end",
 };
 
 /** API Error */
@@ -14,7 +14,7 @@ export default class TopGGAPIError extends Error {
   constructor(text: string, response: Response) {
     if (response.status in tips) {
       super(
-        `${response.status} ${text} (${tips[response.status as keyof typeof tips]})`
+        `${response.status} ${text} (${tips[response.status as keyof typeof tips]})`,
       );
       /* node:coverage ignore next 3 */
     } else {

--- a/tests/Api.test.ts
+++ b/tests/Api.test.ts
@@ -1,7 +1,7 @@
 import { deepStrictEqual, rejects, strictEqual } from "node:assert";
 import { it, describe } from "node:test";
 
-import { MOCK_TOKEN, PARTIAL_VOTE, PROJECT, VOTE } from "./mocks/data";
+import { ANNOUNCEMENT, METRIC, METRIC_BATCH, MOCK_TOKEN, PARTIAL_VOTE, PROJECT, PROJECT_PAYLOAD, VOTE } from "./mocks/data";
 import { registerMocks } from "./mocks/index";
 import { Api, Widget } from "../src/index";
 
@@ -12,6 +12,31 @@ registerMocks();
 describe("API getSelf test", () => {
   it("getSelf should work", async () => {
     deepStrictEqual(await client.getSelf(), PROJECT);
+  });
+});
+
+describe("API editSelf test", () => {
+  it("editSelf should work", async () => {
+    strictEqual(await client.editSelf(PROJECT_PAYLOAD), undefined);
+  });
+});
+
+describe("API postAnnouncement test", () => {
+  it("postAnnouncement should work", async () => {
+    deepStrictEqual(
+      await client.postAnnouncement(ANNOUNCEMENT.title, ANNOUNCEMENT.content),
+      ANNOUNCEMENT
+    );
+  });
+});
+
+describe("API postMetrics test", () => {
+  it("postMetrics single should work", async () => {
+    strictEqual(await client.postMetrics(METRIC), undefined);
+  });
+
+  it("postMetrics batch should work", async () => {
+    strictEqual(await client.postMetrics(METRIC_BATCH), undefined);
   });
 });
 

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -45,6 +45,61 @@ export const PROJECT = {
   }
 };
 
+export const RAW_PROJECT_PAYLOAD = {
+  headline: {
+    en: "A great bot with tons of features!"
+  },
+  page_content: {
+    en: "# Welcome\nThis is the full page description for your project..."
+  }
+}
+
+export const PROJECT_PAYLOAD = {
+  headline: RAW_PROJECT_PAYLOAD.headline,
+  content: RAW_PROJECT_PAYLOAD.page_content
+}
+
+export const RAW_ANNOUNCEMENT = {
+  title: "Version 2.0 Released!",
+  content: "We just released version 2.0 with a bunch of new features and improvements.",
+  created_at: "2026-03-14T15:09:26Z"
+}
+
+export const ANNOUNCEMENT = {
+  title: RAW_ANNOUNCEMENT.title,
+  content: RAW_ANNOUNCEMENT.content,
+  createdAt: RAW_ANNOUNCEMENT.created_at
+}
+
+export const RAW_METRIC = {
+  server_count: 420,
+  shard_count: 67
+}
+
+export const METRIC = {
+  serverCount: RAW_METRIC.server_count,
+  shardCount: RAW_METRIC.shard_count
+}
+
+export const METRIC_BATCH = {
+  timestamp: "2026-04-17T10:00:00Z",
+  serverCount: RAW_METRIC.server_count,
+  shardCount: RAW_METRIC.shard_count
+}
+
+export const RAW_METRIC_BATCH = {
+  data: [
+    {
+      timestamp: "2026-04-17T10:00:00Z",
+      metrics: { server_count: 419 }
+    },
+    {
+      timestamp: "2026-04-17T10:05:00Z",
+      metrics: RAW_METRIC
+    }
+  ]
+}
+
 export const RAW_PARTIAL_VOTE = {
   created_at: "2025-09-09T08:55:16.218761+00:00",
   expires_at: "2025-09-09T20:55:16.218761+00:00",

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -81,11 +81,17 @@ export const METRIC = {
   shardCount: RAW_METRIC.shard_count
 }
 
-export const METRIC_BATCH = {
-  timestamp: "2026-04-17T10:00:00Z",
-  serverCount: RAW_METRIC.server_count,
-  shardCount: RAW_METRIC.shard_count
-}
+export const METRIC_BATCH = [
+  {
+    timestamp: "2026-04-17T10:00:00Z",
+    serverCount: 419
+  },
+  {
+    timestamp: "2026-04-17T10:05:00Z",
+    serverCount: RAW_METRIC.server_count,
+    shardCount: RAW_METRIC.shard_count
+  }
+]
 
 export const RAW_METRIC_BATCH = {
   data: [

--- a/tests/mocks/endpoints.ts
+++ b/tests/mocks/endpoints.ts
@@ -1,10 +1,19 @@
-import { RAW_PAGINATED_VOTES, RAW_PARTIAL_VOTE, RAW_PROJECT } from "./data";
+import {
+  RAW_ANNOUNCEMENT,
+  RAW_METRIC,
+  RAW_METRIC_BATCH,
+  RAW_PAGINATED_VOTES,
+  RAW_PARTIAL_VOTE,
+  RAW_PROJECT,
+  RAW_PROJECT_PAYLOAD
+} from "./data";
 import type { MockInterceptor } from "undici/types/mock-interceptor";
 import { getIdInPath, type MockResponse } from "./index";
+import { Method } from "../../src";
 
 interface MockEndpoint {
   pattern: string;
-  method: string;
+  method: Method;
   data: any;
   validate?: (
     request: MockInterceptor.MockResponseCallbackOptions
@@ -16,6 +25,11 @@ export const endpoints: MockEndpoint[] = [
     pattern: "/api/v1/projects/@me",
     method: "GET",
     data: RAW_PROJECT
+  },
+  {
+    pattern: "/api/v1/projects/@me",
+    method: "PATCH",
+    data: RAW_PROJECT_PAYLOAD
   },
   {
     pattern: "/api/v1/projects/@me/votes/:user_id",
@@ -35,6 +49,21 @@ export const endpoints: MockEndpoint[] = [
     pattern: "/api/v1/projects/@me/commands",
     method: "POST",
     data: ""
+  },
+  {
+    pattern: "/api/v1/projects/@me/announcements",
+    method: "POST",
+    data: RAW_ANNOUNCEMENT
+  },
+  {
+    pattern: "/api/v1/projects/@me/metrics",
+    method: "PATCH",
+    data: RAW_METRIC
+  },
+  {
+    pattern: "/api/v1/projects/@me/metrics/batch",
+    method: "POST",
+    data: RAW_METRIC_BATCH
   },
   {
     pattern: "/api/v1/projects/@me/votes",


### PR DESCRIPTION
This PR adds the missing endpoints for posting:
- bot info (`.editSelf()`)
- announcements (`.postAnnouncement()`)
- metrics (`.postMetrics()`)

I've combined the endpoints `/projects/@me/metrics` and `/projects/@me/metrics/batch` into a single method for user friendliness. Feel free to suggest changes if something feels off!